### PR TITLE
feat(blogs): add userId filtering via URL params and user-specific blog links

### DIFF
--- a/redux-blog/src/features/blogSlice.js
+++ b/redux-blog/src/features/blogSlice.js
@@ -114,7 +114,9 @@ export const blogSliceStatusSelector = (state) => state.blogs.status;
 
 export const blogSliceErrorSelector = (state) => state.blogs.error;
 
-export const allBlogsSelector = (state) => state.blogs.blogs;
+export const allBlogsSelector = (state, userId = null) => {
+  return !userId ? state.blogs.blogs : state.blogs.blogs.filter(blog => blog.userId == userId)
+};
 
 export const blogSelector = (state, blogId) =>
   state.blogs.blogs.find((blog) => blog.id == blogId);

--- a/redux-blog/src/pages/Blog/Blogs.jsx
+++ b/redux-blog/src/pages/Blog/Blogs.jsx
@@ -1,6 +1,6 @@
 import { useDispatch, useSelector } from "react-redux";
 import { Card } from "../../components/ui/Card";
-import { Link } from "react-router-dom";
+import { Link, useParams, useSearchParams } from "react-router-dom";
 import {
   allBlogsSelector,
   blogSliceErrorSelector,
@@ -14,13 +14,16 @@ import { fetchBlogs } from "../../features/blogSlice";
 import Spinner from "../../components/ui/Spinner";
 
 const Blogs = () => {
+  const [searchParams] = useSearchParams();
+  const userId = searchParams.get('userId'); // Correct way to get a param
+
   const blogSliceStatus = useSelector((state) =>
     blogSliceStatusSelector(state)
   );
 
   const blogSliceError = useSelector((state) => blogSliceErrorSelector(state));
 
-  const blogs = useSelector((state) => allBlogsSelector(state));
+  const blogs = useSelector((state) => allBlogsSelector(state, userId));
 
   const dispatch = useDispatch();
 
@@ -29,8 +32,6 @@ const Blogs = () => {
       dispatch(fetchBlogs());
     }
   }, [blogSliceStatus, dispatch]);
-
-  console.log(blogSliceStatus);
 
   if (blogSliceStatus === "loading") {
     return <Spinner />;

--- a/redux-blog/src/pages/user/UserIndex.jsx
+++ b/redux-blog/src/pages/user/UserIndex.jsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { allUsersSelector } from "../../features/userSlice";
 import { useSelector, useDispatch } from "react-redux";
 import { fetchUsers } from "../../features/userSlice";
+import { Link } from "react-router-dom";
 
 const UserIndex = () => {
     const dispatch = useDispatch()
@@ -20,7 +21,9 @@ const UserIndex = () => {
                 {users.map(user => (
                     <tr key={user.id}>
                         <td>{user.id}</td>
-                        <td>{user.fullname}</td>
+                        <td>
+                            <Link to={`/blogs?userId=${user.id}`}>{user.fullname}</Link>
+                        </td>
                     </tr>
                 ))}
             </tbody>


### PR DESCRIPTION
✨ New Features

    Added userId filter to blogs list using URL search params (/blogs?userId=2)

    Implemented user-specific blog links in UserIndex that pass the userId param

    Blogs list now dynamically updates based on URL params

🛠 Technical Implementation

    URL Param Handling

        Uses React Router's useSearchParams() to read userId

        Modified blogs API query to filter by userId when param exists

    New Linking System

        UserIndex now links to /blogs?userId=X instead of generic blogs page

        Added clickable user names/cards that filter their blogs